### PR TITLE
对于自己的项目，发现 单独调用 getRevFrom 的时候，如果没有加入 isset 判断，返回不出正确信息。

### DIFF
--- a/Thinkphp/Wechat.class.php
+++ b/Thinkphp/Wechat.class.php
@@ -193,7 +193,7 @@ class Wechat
 	 * 获取消息发送者
 	 */
 	public function getRevFrom() {
-		if ($this->_receive)
+		if (isset($this->_receive))
 			return $this->_receive['FromUserName'];
 		else 
 			return false;
@@ -203,7 +203,7 @@ class Wechat
 	 * 获取消息接受者
 	 */
 	public function getRevTo() {
-		if ($this->_receive)
+		if (isset($this->_receive))
 			return $this->_receive['ToUserName'];
 		else 
 			return false;


### PR DESCRIPTION
```
            //判断发送过来的信息类型
    case Wechat::MSGTYPE_TEXT:

            $backText = $weObj->getRev()->getRevContent();

            if (strcmp($backText,"我的连续剧") == 0) {

                $formWho = $weObj->getRev()->getRevFrom();

                $weObj->text($formWho)->reply();

                break;
            }
```

在微信后台中，当只使用官方的Wechat，想获取用户的id，原getRevFrom返回一直是false，在加入 isset 后就能正确判断，虽然很奇怪，但是这样的确就正常了。

Signed-off-by: 716 525223688@qq.com
