### PR TITLE
修复自定义渠道二维码错误

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -764,6 +764,9 @@ class Wechat
 			'expire_seconds'=>$expire,
 			'action_info'=>array('scene'=>array('scene_id'=>$scene_id))
 		);
+		if ($type == 1) {
+			unset($data['expire_seconds']);
+		}
 		$result = $this->http_post(self::API_URL_PREFIX.self::QRCODE_CREATE_URL.'access_token='.$this->access_token,self::json_encode($data));
 		if ($result)
 		{


### PR DESCRIPTION
修复了一个生成永久二维码的错误：如果生成永久二维码而又有'expire_seconds'这个参数的时候，会得到ticket但是无法得到二维码。
