### PR TITLE
Array sort方法中把值作为字符串来处理

### DIFF
--- a/Thinkphp/Wechat.class.php
+++ b/Thinkphp/Wechat.class.php
@@ -108,7 +108,10 @@ class Wechat
         		
 		$token = $this->token;
 		$tmpArr = array($token, $timestamp, $nonce);
-		sort($tmpArr);
+
+    # 把值作为字符串来处理
+    sort($tmpArr, SORT_STRING);
+
 		$tmpStr = implode( $tmpArr );
 		$tmpStr = sha1( $tmpStr );
 		


### PR DESCRIPTION
Bug描述：
如果用户手动填写token为 2014或者2022等在php整型能接受的范围的值，则会出现验证失败！

解决方案：
在 Wechat.class.php 中的checkSignature方法中，加入SORT_STRING参数，把值作为字符串来处理。
