### PR TITLE
修复了登陆时出错

### DIFF
--- a/Thinkphp/Wechatext.class.php
+++ b/Thinkphp/Wechatext.class.php
@@ -619,7 +619,7 @@ class Wechatext
 				$cookie .=$match[1].'='.$match[2].'; ';
 		}
 		
-		preg_match("/token=(\d+)/i",$result['ErrMsg'],$matches);
+		preg_match("/token=(\d+)/i",$result['redirect_url'],$matches);
 		if($matches){
 			$this->_token = $matches[1];
 			$this->log('token:'.$this->_token);


### PR DESCRIPTION
登陆页面返回的json改变了
if ($result['ErrCode']!=0) return false; 改为 if ($result['base_resp']['err_msg']!='ok') return false;
preg_match("/token=(\d+)/i",$result['ErrMsg'],$matches); 改为 preg_match("/token=(\d+)/i",$result['redirect_url'],$matches);
