### PR TITLE
Update wechat.class.php

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -313,7 +313,19 @@ class Wechat
 		} else 
 			return false;
 	}
-	
+	/**
+	 * 获取上报地理位置事件
+	 */
+	public function getRevEventGeo(){
+        	if (isset($this->_receive['Latitude'])){
+        		 return array(
+				'x'=>$this->_receive['Latitude'],
+				'y'=>$this->_receive['Longitude'],
+				'precision'=>$this->_receive['Precision'],
+			);
+		} else
+			return false;
+	}
 	/**
 	 * 获取接收事件推送
 	 */


### PR DESCRIPTION
getRevEventGeo()用户同意上报地理位置后，每次进入公众号会话时，都会在进入时上报地理位置，或在进入会话后每5秒上报一次地理位置,获取用户地理位置信息
