### PR TITLE
Update snoopy.class.php

### DIFF
--- a/snoopy.class.php
+++ b/snoopy.class.php
@@ -1002,6 +1002,7 @@ class Snoopy
 			curl_setopt($ch, CURLOPT_HEADER, true); 
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+			curl_setopt($ch, CURLOPT_SSLVERSION,3); 
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
 			curl_setopt($ch, CURLOPT_HTTPHEADER, $headers); 
 			curl_setopt($ch, CURLOPT_TIMEOUT, $this->read_timeout);


### PR DESCRIPTION
微信升级了ssl，改一下这个就可以用了，前提是支持php-curl模块
