### PR TITLE
fix error at no "EventKey" field in the post xml message which received ...

### DIFF
--- a/Thinkphp/Wechat.class.php
+++ b/Thinkphp/Wechat.class.php
@@ -352,12 +352,17 @@ class Wechat
 	 */
 	public function getRevEvent(){
 		if (isset($this->_receive['Event'])){
-			return array(
-				'event'=>$this->_receive['Event'],
-				'key'=>$this->_receive['EventKey'],
-			);
-		} else 
+			$array['event'] = $this->_receive['Event'];
+		}
+		if (isset($this->_receive['EventKey'])){
+			$array['key'] = $this->_receive['EventKey'];
+		}
+		
+		if (isset($array) && count($array) > 0) {
+			return $array;
+		} else {
 			return false;
+		} 
 	}
 	
 	/**


### PR DESCRIPTION
...from wechat;

在调试的时候发现，微信的关注/取消事件的消息体，是不含“EventKey” 字段的。所以在调用getRevEvent() 时报错了。所以作了修改。
