### PR TITLE
使用isset判断$echoStr是否定义。

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -183,7 +183,7 @@ class Wechat
             $echoStr = isset($_GET["echostr"]) ? $_GET["echostr"]: '';
         }
         if ($return) {
-        		if ($echoStr) {
+        		if (isset($echoStr)) {
         			if ($this->checkSignature($encryptStr)) 
         				return $echoStr;
         			else
@@ -191,7 +191,7 @@ class Wechat
         		} else 
         			return $this->checkSignature($encryptStr);
         } else {
-	        	if ($echoStr) {
+	        	if (isset($echoStr)) {
 	        		if ($this->checkSignature($encryptStr))
 	        			die($echoStr);
 	        		else 


### PR DESCRIPTION
valid方法里如果是post请求，$echoStr没有定义，在一些php版本中会出现 `Undefined variable: echoStr` 的报错。
