### PR TITLE
修复加密模式下没有appid的订阅号无法被动回复的问题。

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -176,6 +176,7 @@ class Wechat
             	    }
             	}
             	$this->postxml = $array[1];
+            	$this->appid = $array[2];//为了没有appid的订阅号。
             } else {
                 $this->postxml = $postStr;
             }
@@ -2129,9 +2130,11 @@ class Prpcrypt
             print $e;
             return array(ErrorCode::$IllegalBuffer, null);
         }
-        if ($from_appid != $appid)
-            return array(ErrorCode::$ValidateAppidError, null);
-        return array(0, $xml_content);
+        //if ($from_appid != $appid)
+            //return array(ErrorCode::$ValidateAppidError, null);
+        //注释上面两行是为了没有appid的订阅号
+        
+        return array(0, $xml_content, $from_appid); //增加appid，为了解决后面加密回复消息的时候没有appid的订阅号会无法回复
 
     }
 


### PR DESCRIPTION
经过我们（weixinhost.com）一个上午的调试，发现虽然没有appid的订阅号可以使用加密模式，并且可以在没有appid的情况下正常解密，但是在被动回复的时候如果用空appid加密是不行的，微信不会回复给粉丝。
而同时我们发现解密后是不管帐号有没有appid都会携带一个appid，而用这个appid给消息加密回复就正常了。
因此做了这个修改。
