### PR TITLE
公众号类库修改解密时订阅号appid问题的解决代码/代码同步修改/注释异常输出代码

### DIFF
--- a/Thinkphp/Wechat.class.php
+++ b/Thinkphp/Wechat.class.php
@@ -176,6 +176,8 @@ class Wechat
             	    }
             	}
             	$this->postxml = $array[1];
+            	if (!$this->appid)
+            	    $this->appid = $array[2];//为了没有appid的订阅号。
             } else {
                 $this->postxml = $postStr;
             }
@@ -183,7 +185,7 @@ class Wechat
             $echoStr = isset($_GET["echostr"]) ? $_GET["echostr"]: '';
         }
         if ($return) {
-        		if ($echoStr) {
+        		if (isset($echoStr)) {
         			if ($this->checkSignature($encryptStr)) 
         				return $echoStr;
         			else
@@ -191,7 +193,7 @@ class Wechat
         		} else 
         			return $this->checkSignature($encryptStr);
         } else {
-	        	if ($echoStr) {
+	        	if (isset($echoStr)) {
 	        		if ($this->checkSignature($encryptStr))
 	        			die($echoStr);
 	        		else 
@@ -2076,7 +2078,7 @@ class Prpcrypt
 
         try {
             //获得16位随机字符串，填充到明文之前
-            $random = "aaaabbbbccccdddd"; //$this->getRandomStr();
+            $random = $this->getRandomStr();//"aaaabbbbccccdddd"; 
             $text = $random . pack("N", strlen($text)) . $text . $appid;
             // 网络字节序
             $size = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
@@ -2095,7 +2097,7 @@ class Prpcrypt
             //使用BASE64对加密后的字符串进行编码
             return array(ErrorCode::$OK, base64_encode($encrypted));
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$EncryptAESError, null);
         }
     }
@@ -2135,13 +2137,17 @@ class Prpcrypt
             $xml_len = $len_list[1];
             $xml_content = substr($content, 4, $xml_len);
             $from_appid = substr($content, $xml_len + 4);
+            if (!$appid)
+                $appid = $from_appid;
+            //如果传入的appid是空的，则认为是订阅号，使用数据中提取出来的appid
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$IllegalBuffer, null);
         }
         if ($from_appid != $appid)
             return array(ErrorCode::$ValidateAppidError, null);
-        return array(0, $xml_content);
+        //不注释上边两行，避免传入appid是错误的情况
+        return array(0, $xml_content, $from_appid); //增加appid，为了解决后面加密回复消息的时候没有appid的订阅号会无法回复
 
     }
 

--- a/Thinkphp/qywechat.class.php
+++ b/Thinkphp/qywechat.class.php
@@ -1793,7 +1793,7 @@ class Prpcrypt
 
         try {
             //获得16位随机字符串，填充到明文之前
-            $random = "aaaabbbbccccdddd"; //$this->getRandomStr();
+            $random = $this->getRandomStr();//"aaaabbbbccccdddd"; 
             $text = $random . pack("N", strlen($text)) . $text . $appid;
             // 网络字节序
             $size = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
@@ -1812,7 +1812,7 @@ class Prpcrypt
             //使用BASE64对加密后的字符串进行编码
             return array(ErrorCode::$OK, base64_encode($encrypted));
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$EncryptAESError, null);
         }
     }
@@ -1853,7 +1853,7 @@ class Prpcrypt
             $xml_content = substr($content, 4, $xml_len);
             $from_appid = substr($content, $xml_len + 4);
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$IllegalBuffer, null);
         }
         if ($from_appid != $appid)

--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -1784,7 +1784,7 @@ class Prpcrypt
 
         try {
             //获得16位随机字符串，填充到明文之前
-            $random = "aaaabbbbccccdddd"; //$this->getRandomStr();
+            $random = $this->getRandomStr();//"aaaabbbbccccdddd"; 
             $text = $random . pack("N", strlen($text)) . $text . $appid;
             // 网络字节序
             $size = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
@@ -1803,7 +1803,7 @@ class Prpcrypt
             //使用BASE64对加密后的字符串进行编码
             return array(ErrorCode::$OK, base64_encode($encrypted));
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$EncryptAESError, null);
         }
     }
@@ -1844,7 +1844,7 @@ class Prpcrypt
             $xml_content = substr($content, 4, $xml_len);
             $from_appid = substr($content, $xml_len + 4);
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$IllegalBuffer, null);
         }
         if ($from_appid != $appid)

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -176,7 +176,8 @@ class Wechat
             	    }
             	}
             	$this->postxml = $array[1];
-            	$this->appid = $array[2];//为了没有appid的订阅号。
+            	if (!$this->appid)
+            	    $this->appid = $array[2];//为了没有appid的订阅号。
             } else {
                 $this->postxml = $postStr;
             }
@@ -2067,7 +2068,7 @@ class Prpcrypt
 
         try {
             //获得16位随机字符串，填充到明文之前
-            $random = "aaaabbbbccccdddd"; //$this->getRandomStr();
+            $random = $this->getRandomStr();//"aaaabbbbccccdddd"; 
             $text = $random . pack("N", strlen($text)) . $text . $appid;
             // 网络字节序
             $size = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
@@ -2086,7 +2087,7 @@ class Prpcrypt
             //使用BASE64对加密后的字符串进行编码
             return array(ErrorCode::$OK, base64_encode($encrypted));
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$EncryptAESError, null);
         }
     }
@@ -2126,14 +2127,16 @@ class Prpcrypt
             $xml_len = $len_list[1];
             $xml_content = substr($content, 4, $xml_len);
             $from_appid = substr($content, $xml_len + 4);
+            if (!$appid)
+                $appid = $from_appid;
+            //如果传入的appid是空的，则认为是订阅号，使用数据中提取出来的appid
         } catch (Exception $e) {
-            print $e;
+            //print $e;
             return array(ErrorCode::$IllegalBuffer, null);
         }
-        //if ($from_appid != $appid)
-            //return array(ErrorCode::$ValidateAppidError, null);
-        //注释上面两行是为了没有appid的订阅号
-        
+        if ($from_appid != $appid)
+            return array(ErrorCode::$ValidateAppidError, null);
+        //不注释上边两行，避免传入appid是错误的情况
         return array(0, $xml_content, $from_appid); //增加appid，为了解决后面加密回复消息的时候没有appid的订阅号会无法回复
 
     }


### PR DESCRIPTION
1、公众号类库 修改关于解密时订阅号appid问题的解决代码，避免服务号appid错误而无法检测到，且覆盖掉服务号appid的情况

> valid()方法中修改：
> 
> ``` php
>                 $this->postxml = $array[1];
> -               $this->appid = $array[2];//为了没有appid的订阅号。
> +               if (!$this->appid)
> +                   $this->appid = $array[2];//为了没有appid的订阅号。
> ```
> 
> decrypt($encrypted, $appid) 方法中修改：
> 
> ``` php
>              $from_appid = substr($content, $xml_len + 4);
> +            if (!$appid)
> +                $appid = $from_appid;
> +            //如果传入的appid是空的，则认为是订阅号，使用数据中提取出来的appid
>          } catch (Exception $e) {
> -            print $e;
> +            //print $e;
>              return array(ErrorCode::$IllegalBuffer, null);
>          }
> -        //if ($from_appid != $appid)
> -            //return array(ErrorCode::$ValidateAppidError, null);
> -        //注释上面两行是为了没有appid的订阅号
> -        
> +        if ($from_appid != $appid)
> +            return array(ErrorCode::$ValidateAppidError, null);
> +        //不注释上边两行，避免传入appid是错误的情况
>          return array(0, $xml_content, $from_appid); //增加appid，为了解决后面加密回复消息的时候没有appid的订阅号会无法回复
> ```

2、公众号类库、企业号类库 注释掉加密库的异常输出代码；调用方法生成随机字符串，而不再使用固定的字符串了

> 修改内容：
> 
> ``` php
> -            $random = "aaaabbbbccccdddd"; //$this->getRandomStr();
> +            $random = $this->getRandomStr();//"aaaabbbbccccdddd"; 
> ```
> 
> ``` php
>          } catch (Exception $e) {
> -            print $e;
> +            //print $e;
>              return array(ErrorCode::$IllegalBuffer, null);
>          }
> ```
> 
> ``` php
>          } catch (Exception $e) {
> -            print $e;
> +            //print $e;
>              return array(ErrorCode::$EncryptAESError, null);
>          }
> ```

以上为修改的部分
