### PR TITLE
Update wechat.class.php

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -1731,10 +1731,10 @@ class Wechat
 				"appid"=>$this->appid,
 				"appkey"=>$this->paysignkey,
 				"openid"=>$openid,
-				"transid"=>strval($transid),
-				"out_trade_no"=>strval($out_trade_no),
-				"deliver_timestamp"=>strval(time()),
-				"deliver_status"=>strval($status),
+				"transid"=>$transid,
+				"out_trade_no"=>$out_trade_no,
+				"deliver_timestamp"=>time(),
+				"deliver_status"=>$status,
 				"deliver_msg"=>$msg,
 		);
 		$postdata['app_signature'] = $this->getSignature($postdata);


### PR DESCRIPTION
发货通知  (sendPayDeliverNotify ) 函数生成签名串用strval转化时会有错误（微信提示49004 支付签名错误）
"transid"=>strval($transid),
"out_trade_no"=>strval($out_trade_no),
"deliver_timestamp"=>strval(time()),
"deliver_status"=>strval($status),

 Author：zhangruizhou
Date：2014-11-12