### PR TITLE
修复json_encode方法bug

### DIFF
--- a/Thinkphp/Wechat.class.php
+++ b/Thinkphp/Wechat.class.php
@@ -969,7 +969,7 @@ class Wechat
 				if (! $is_list)
 					$str = '"' . $key . '":';
 				//Custom handling for multiple data types
-				if (is_numeric ( $value ) && $value<2000000000)
+				if (!is_string ( $value ) && is_numeric ( $value ) && $value<2000000000)
 					$str .= $value; //Numbers
 				elseif ($value === false)
 				$str .= 'false'; //The booleans

--- a/Thinkphp/qywechat.class.php
+++ b/Thinkphp/qywechat.class.php
@@ -176,7 +176,7 @@ class Wechat
 	            if (! $is_list)
 	                $str = '"' . $key . '":';
 	            //Custom handling for multiple data types
-	            if (is_numeric ( $value ) && $value<2000000000)
+	            if (!is_string ( $value ) && is_numeric ( $value ) && $value<2000000000)
 	                $str .= $value; //Numbers
 	            elseif ($value === false)
 	            $str .= 'false'; //The booleans

--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -171,7 +171,7 @@ class Wechat
 	            if (! $is_list)
 	                $str = '"' . $key . '":';
 	            //Custom handling for multiple data types
-	            if (is_numeric ( $value ) && $value<2000000000)
+	            if (!is_string ( $value ) && is_numeric ( $value ) && $value<2000000000)
 	                $str .= $value; //Numbers
 	            elseif ($value === false)
 	            $str .= 'false'; //The booleans

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -959,7 +959,7 @@ class Wechat
 				if (! $is_list)
 					$str = '"' . $key . '":';
 				//Custom handling for multiple data types
-				if (is_numeric ( $value ) && $value<2000000000)
+				if (!is_string ( $value ) && is_numeric ( $value ) && $value<2000000000)
 					$str .= $value; //Numbers
 				elseif ($value === false)
 				$str .= 'false'; //The booleans


### PR DESCRIPTION
当传入数组内值为数字字符串，会被作为数字处理，在某些时候可能会引起错误。
如测试数组：

``` php
$arr = array(
    "str"=>"12345",
    "zh"=>"“中文测试”",
    "int"=>201,
    "t"=>true,
    "f"=>false,
    "ts"=>1,
    "arr"=>array(
        "int"=>101,
        "textint"=>"102",
        "cn"=>"测试"
    )
);
```

php5.4以后，原生的json_encode增加了一个选项，可以直接避免中文被转码，如：

``` php
json_encode($arr,JSON_UNESCAPED_UNICODE)
```

由于国内多数主机空间还是5.3甚至5.2的，所以还是使用类内的json_encode进行代替。

使用以前的代码，与原生json_encode使用JSON_UNESCAPED_UNICODE的输出结果对比：

```
string(121) "{"str":12345,"zh":"“中文测试”","int":201,"t":true,"f":false,"ts":1,"arr":{"int":101,"textint":102,"cn":"测试"}}" 
string(125) "{"str":"12345","zh":"“中文测试”","int":201,"t":true,"f":false,"ts":1,"arr":{"int":101,"textint":"102","cn":"测试"}}" 
```

可以看到字符串形式的数字，在生成的json里，被作为数字生成了。这样会再某些时候可能导致问题
对类内的json_encode进行修复，再测试结果：

```
string(125) "{"str":"12345","zh":"“中文测试”","int":201,"t":true,"f":false,"ts":1,"arr":{"int":101,"textint":"102","cn":"测试"}}" 
string(125) "{"str":"12345","zh":"“中文测试”","int":201,"t":true,"f":false,"ts":1,"arr":{"int":101,"textint":"102","cn":"测试"}}" 
```

完整测试代码：

```
<?php 
/**
 * 微信api不支持中文转义的json结构
 * @param array $arr
 */
function json($arr) {
    $parts = array ();
    $is_list = false;
    //Find out if the given array is a numerical array
    $keys = array_keys ( $arr );
    $max_length = count ( $arr ) - 1;
    if (($keys [0] === 0) && ($keys [$max_length] === $max_length )) { //See if the first key is 0 and last key is length - 1
        $is_list = true;
        for($i = 0; $i < count ( $keys ); $i ++) { //See if each key correspondes to its position
            if ($i != $keys [$i]) { //A key fails at position check.
                $is_list = false; //It is an associative array.
                break;
            }
        }
    }
    foreach ( $arr as $key => $value ) {
        if (is_array ( $value )) { //Custom handling for arrays
            if ($is_list)
                $parts [] = json ( $value ); /* :RECURSION: */
            else
                $parts [] = '"' . $key . '":' . json ( $value ); /* :RECURSION: */
        } else {
            $str = '';
            if (! $is_list)
                $str = '"' . $key . '":';
            //Custom handling for multiple data types
            if (!is_string ( $value ) && is_numeric ( $value ) && $value<2000000000)
                $str .= $value; //Numbers
            elseif ($value === false)
            $str .= 'false'; //The booleans
            elseif ($value === true)
            $str .= 'true';
            else
                $str .= '"' . addslashes ( $value ) . '"'; //All other things
            // :TODO: Is there any more datatype we should be in the lookout for? (Object?)
            $parts [] = $str;
        }
    }
    $json = implode ( ',', $parts );
    if ($is_list)
        return '[' . $json . ']'; //Return numerical JSON
    return '{' . $json . '}'; //Return associative JSON
}
$arr = array(
    "str"=>"12345",
    "zh"=>"“中文测试”",
    "int"=>201,
    "t"=>true,
    "f"=>false,
    "ts"=>1,
    "arr"=>array(
        "int"=>101,
        "textint"=>"102",
        "cn"=>"测试"
    )
);
$ret =json($arr);
var_dump($ret);
echo "<br>";
echo "<br>";
$ret=json_encode($arr,JSON_UNESCAPED_UNICODE);
var_dump($ret);
echo "<br>";
echo "<br>";
var_dump($arr);
?>
```
