### PR TITLE
Update wechat.js

### DIFF
--- a/wechat.js
+++ b/wechat.js
@@ -66,7 +66,7 @@
 	   		alert(res.err_desc);
 	   	}
 	   	//分享到朋友圈
-	   	if (res.err_msg=='share_timeline:confirm') {
+	   	if (res.err_msg=='share_timeline:ok') {
 	   		//todo:func1();
 	   		alert(res.err_desc);
 	   	}


### PR DESCRIPTION
微信分享到朋友圈的JS貌似改过了,现在是share_timeline:ok,只测分享到朋友圈的其他的没测
