### PR TITLE
 统一getJsSign方法变量及返回值的大小写

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ https://mp.weixin.qq.com/cgi-bin/readtemplate?t=business/course2_tmpl&lang=zh_CN
  *  resetAuth($appid='') 删除验证数据
  *  resetJsTicket($appid='') 删除JSAPI授权TICKET
  *  getJsTicket($appid='',$jsapi_ticket='') 获取JSAPI授权TICKET
- *  getJsSign($url, $timeStamp=0, $nonceStr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
+ *  getJsSign($url, $timestamp=0, $noncestr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
  *  createMenu($data) 创建菜单 $data菜单结构详见 **[自定义菜单创建接口](http://mp.weixin.qq.com/wiki/index.php?title=自定义菜单创建接口)**
  *  getServerIp() 获取微信服务器IP地址列表 返回数组array('127.0.0.1','127.0.0.1')
  *  getMenu() 获取菜单 
@@ -411,7 +411,7 @@ $options = array(
 * resetAuth($appid='') 清除记录的ACCESS_TOKEN
 * resetJsTicket($appid='') 删除JSAPI授权TICKET
 * getJsTicket($appid='',$jsapi_ticket='') 获取JSAPI授权TICKET
-* getJsSign($url, $timeStamp=0, $nonceStr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
+* getJsSign($url, $timestamp=0, $noncestr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
 * getSignature($arrdata,'sha1') 生成签名字串  
 * generateNonceStr($length=16) 获取随机字串  
 * createMenu($data,$agentid='') 创建菜单,参数:菜单内容数组,要创建菜单应用id

--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -987,8 +987,8 @@ class Wechat
 	    if (!$sign)
 	        return false;
 	    $signPackage = array(
-	            "appId"     => $this->appid,
-	            "nonceStr"  => $nonceStr,
+	            "appid"     => $this->appid,
+	            "noncestr"  => $nonceStr,
 	            "timestamp" => $timestamp,
 	            "url"       => $url,
 	            "signature" => $sign

--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -46,7 +46,7 @@ class Wechat
     const EVENT_SEND_TEMPLATE = 'TEMPLATESENDJOBFINISH';//发送结果 - 模板消息发送结果
 
     const API_URL_PREFIX = 'https://qyapi.weixin.qq.com/cgi-bin';
-    
+
     const USER_CREATE_URL 		= '/user/create?';
     const USER_UPDATE_URL 		= '/user/update?';
     const USER_DELETE_URL 		= '/user/delete?';
@@ -965,30 +965,30 @@ class Wechat
 	/**
 	 * 获取JsApi使用签名
 	 * @param string $url 网页的URL，自动处理#及其后面部分
-	 * @param string $timeStamp 当前时间戳 (为空则自动生成)
-	 * @param string $nonceStr 随机串 (为空则自动生成)
+	 * @param string $timestamp 当前时间戳 (为空则自动生成)
+	 * @param string $noncestr 随机串 (为空则自动生成)
 	 * @param string $appid 用于多个appid时使用,可空
 	 * @return array|bool 返回签名字串
 	 */
-	public function getJsSign($url, $timeStamp=0, $nonceStr='', $appid=''){
+	public function getJsSign($url, $timestamp=0, $noncestr='', $appid=''){
 	    if (!$this->jsapi_ticket && !$this->getJsTicket($appid) || !$url) return false;
-	    if (!$timeStamp)
-	        $timeStamp = time();
-	    if (!$nonceStr)
-	        $nonceStr = $this->generateNonceStr();
+	    if (!$timestamp)
+	        $timestamp = time();
+	    if (!$noncestr)
+	        $noncestr = $this->generateNonceStr();
 	    $ret = strpos($url,'#');
 	    if ($ret)
 	        $url = substr($url,0,$ret);
 	    $url = trim($url);
 	    if (empty($url))
 	        return false;
-	    $arrdata = array("timestamp" => $timeStamp, "noncestr" => $nonceStr, "url" => $url, "jsapi_ticket" => $this->jsapi_ticket);
+	    $arrdata = array("timestamp" => $timestamp, "noncestr" => $noncestr, "url" => $url, "jsapi_ticket" => $this->jsapi_ticket);
 	    $sign = $this->getSignature($arrdata);
 	    if (!$sign)
 	        return false;
 	    $signPackage = array(
 	            "appid"     => $this->appid,
-	            "noncestr"  => $nonceStr,
+	            "noncestr"  => $noncestr,
 	            "timestamp" => $timestamp,
 	            "url"       => $url,
 	            "signature" => $sign

--- a/test/jsapi/jsapi_demo.php
+++ b/test/jsapi/jsapi_demo.php
@@ -7,7 +7,6 @@ $opt = array(
         'appid'=>'wxxxxxxxxxxxxxx'	//填写高级调用功能的appid
 );
 
-logg("GET参数为：\n".var_export($_GET,true));
 $we = new Wechat($opt);
 $auth = $we->checkAuth();
 $js_ticket = $we->getJsTicket();
@@ -17,10 +16,8 @@ if (!$js_ticket) {
     echo ' 错误原因：'.ErrCode::getErrText($weObj->errCode);
     exit;
 }
-$timestamp = time();
-$noncestr = $we->generateNonceStr();
 $url = 'http://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-$js_sign = $we->getJsSign($url, $timestamp, $noncestr);
+$js_sign = $we->getJsSign($url);
 ?>
 <!DOCTYPE html>
 <html>
@@ -146,10 +143,10 @@ $js_sign = $we->getJsSign($url, $timestamp, $noncestr);
 <script>
   wx.config({
       debug: false,
-      appId: '<?php echo $opt['appid']; ?>', // 必填，公众号的唯一标识
-      timestamp: <?php echo $timestamp; ?>, // 必填，生成签名的时间戳
-      nonceStr: '<?php echo $noncestr; ?>', // 必填，生成签名的随机串
-      signature: '<?php echo $js_sign; ?>', // 必填，签名，见附录1
+      appId: '<?php echo $js_sign['appid']; ?>', // 必填，公众号的唯一标识
+      timestamp: <?php echo $js_sign['timestamp']; ?>, // 必填，生成签名的时间戳，切记时间戳是整数型，别加引号
+      nonceStr: '<?php echo $js_sign['noncestr']; ?>', // 必填，生成签名的随机串
+      signature: '<?php echo $js_sign['signature']; ?>', // 必填，签名，见附录1
       jsApiList: [
         'checkJsApi',
         'onMenuShareTimeline',

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -1207,30 +1207,30 @@ class Wechat
 	/**
 	 * 获取JsApi使用签名
 	 * @param string $url 网页的URL，自动处理#及其后面部分
-	 * @param string $timeStamp 当前时间戳 (为空则自动生成)
-	 * @param string $nonceStr 随机串 (为空则自动生成)
+	 * @param string $timestamp 当前时间戳 (为空则自动生成)
+	 * @param string $noncestr 随机串 (为空则自动生成)
 	 * @param string $appid 用于多个appid时使用,可空
 	 * @return array|bool 返回签名字串
 	 */
-	public function getJsSign($url, $timeStamp=0, $nonceStr='', $appid=''){
+	public function getJsSign($url, $timestamp=0, $noncestr='', $appid=''){
 	    if (!$this->jsapi_ticket && !$this->getJsTicket($appid) || !$url) return false;
-	    if (!$timeStamp)
-	        $timeStamp = time();
-	    if (!$nonceStr)
-	        $nonceStr = $this->generateNonceStr();
+	    if (!$timestamp)
+	        $timestamp = time();
+	    if (!$noncestr)
+	        $noncestr = $this->generateNonceStr();
 	    $ret = strpos($url,'#');
 	    if ($ret)
 	        $url = substr($url,0,$ret);
 	    $url = trim($url);
 	    if (empty($url))
 	        return false;
-	    $arrdata = array("timestamp" => $timeStamp, "noncestr" => $nonceStr, "url" => $url, "jsapi_ticket" => $this->jsapi_ticket);
+	    $arrdata = array("timestamp" => $timestamp, "noncestr" => $noncestr, "url" => $url, "jsapi_ticket" => $this->jsapi_ticket);
 	    $sign = $this->getSignature($arrdata);
 	    if (!$sign)
 	        return false;
 	    $signPackage = array(
 	            "appid"     => $this->appid,
-	            "noncestr"  => $nonceStr,
+	            "noncestr"  => $noncestr,
 	            "timestamp" => $timestamp,
 	            "url"       => $url,
 	            "signature" => $sign

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -1229,8 +1229,8 @@ class Wechat
 	    if (!$sign)
 	        return false;
 	    $signPackage = array(
-	            "appId"     => $this->appid,
-	            "nonceStr"  => $nonceStr,
+	            "appid"     => $this->appid,
+	            "noncestr"  => $nonceStr,
 	            "timestamp" => $timestamp,
 	            "url"       => $url,
 	            "signature" => $sign

--- a/wiki/企业号API类库.md
+++ b/wiki/企业号API类库.md
@@ -99,7 +99,7 @@ $options = array(
 * resetAuth($appid='') 清除记录的ACCESS_TOKEN
 * resetJsTicket($appid='') 删除JSAPI授权TICKET
 * getJsTicket($appid='',$jsapi_ticket='') 获取JSAPI授权TICKET
-* getJsSign($url, $timeStamp=0, $nonceStr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
+* getJsSign($url, $timestamp=0, $noncestr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
 * getSignature($arrdata,'sha1') 生成签名字串  
 * generateNonceStr($length=16) 获取随机字串  
 * createMenu($data,$agentid='') 创建菜单,参数:菜单内容数组,要创建菜单应用id

--- a/wiki/官方API类库.md
+++ b/wiki/官方API类库.md
@@ -124,7 +124,7 @@
  *  resetAuth($appid='') 删除验证数据
  *  resetJsTicket($appid='') 删除JSAPI授权TICKET
  *  getJsTicket($appid='',$jsapi_ticket='') 获取JSAPI授权TICKET
- *  getJsSign($url, $timeStamp=0, $nonceStr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
+ *  getJsSign($url, $timestamp=0, $noncestr='', $appid='') 获取JsApi使用签名信息数组，可只提供url地址 
  *  createMenu($data) 创建菜单 $data菜单结构详见 **[自定义菜单创建接口](http://mp.weixin.qq.com/wiki/index.php?title=自定义菜单创建接口)**
  *  getServerIp() 获取微信服务器IP地址列表 返回数组array('127.0.0.1','127.0.0.1')
  *  getMenu() 获取菜单 


### PR DESCRIPTION
@dodgepudding 按你说的，修复来了
 统一getJsSign方法变量及返回值的大小写
```
	/**
	 * 获取JsApi使用签名
	 * @param string $url 网页的URL，自动处理#及其后面部分
	 * @param string $timestamp 当前时间戳 (为空则自动生成)
	 * @param string $noncestr 随机串 (为空则自动生成)
	 * @param string $appid 用于多个appid时使用,可空
	 * @return array|bool 返回签名字串
	 */
	public function getJsSign($url, $timestamp=0, $noncestr='', $appid=''){
	    if (!$this->jsapi_ticket && !$this->getJsTicket($appid) || !$url) return false;
	    if (!$timestamp)
	        $timestamp = time();
	    if (!$noncestr)
	        $noncestr = $this->generateNonceStr();
	    $ret = strpos($url,'#');
	    if ($ret)
	        $url = substr($url,0,$ret);
	    $url = trim($url);
	    if (empty($url))
	        return false;
	    $arrdata = array("timestamp" => $timestamp, "noncestr" => $noncestr, "url" => $url, "jsapi_ticket" => $this->jsapi_ticket);
	    $sign = $this->getSignature($arrdata);
	    if (!$sign)
	        return false;
	    $signPackage = array(
	            "appid"     => $this->appid,
	            "noncestr"  => $noncestr,
	            "timestamp" => $timestamp,
	            "url"       => $url,
	            "signature" => $sign
	    );
	    return $signPackage;
	}
```
此方法返回的数组，需要在前端页面用如下写入：
```
............省略
$js_sign = $we->getJsSign($url);
............省略
<script>
  wx.config({
      debug: false,
      appId: '<?php echo $js_sign['appid']; ?>', // 必填，公众号的唯一标识
      timestamp: <?php echo $js_sign['timestamp']; ?>, // 必填，生成签名的时间戳，切记时间戳是整数型，别加引号
      nonceStr: '<?php echo $js_sign['noncestr']; ?>', // 必填，生成签名的随机串
      signature: '<?php echo $js_sign['signature']; ?>', // 必填，签名，见附录1
      jsApiList: [     ]
  });
</script>
```
需要注意的是在js里，参数名称是驼峰法的，而getJsSign方法返回的数组键名是全小写。