### PR TITLE
修复bug: Prpcrypt类 兼容构造函数 位置顺序问题导致报错

### DIFF
--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -2087,15 +2087,15 @@ class Prpcrypt
 {
     public $key;
 
-    /**
-     * 兼容老版本php构造函数
-     */
-    function Prpcrypt($k)
-    {
+    function __construct($k) {
         $this->key = base64_decode($k . "=");
     }
 
-    function __construct($k) {
+    /**
+     * 兼容老版本php构造函数，不能在 __construct() 方法前边，否则报错
+     */
+    function Prpcrypt($k)
+    {
         $this->key = base64_decode($k . "=");
     }
 

--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -937,7 +937,7 @@ class Wechat
 		if (!$appid) $appid = $this->appid;
 		if ($jsapi_ticket) { //手动指定token，优先使用
 		    $this->jsapi_ticket = $jsapi_ticket;
-		    return $this->access_token;
+		    return $this->jsapi_ticket;
 		}
 		$authname = 'qywechat_jsapi_ticket'.$appid;
 		if ($rs = $this->getCache($authname))  {

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -1208,7 +1208,7 @@ class Wechat
 		if (!$appid) $appid = $this->appid;
 		if ($jsapi_ticket) { //手动指定token，优先使用
 		    $this->jsapi_ticket = $jsapi_ticket;
-		    return $this->access_token;
+		    return $this->jsapi_ticket;
 		}
 		$authname = 'wechat_jsapi_ticket'.$appid;
 		if ($rs = $this->getCache($authname))  {

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -3210,15 +3210,15 @@ class Prpcrypt
 {
     public $key;
 
-    /**
-     * 兼容老版本php构造函数
-     */
-    function Prpcrypt($k)
-    {
+    function __construct($k) {
         $this->key = base64_decode($k . "=");
     }
 
-    function __construct($k) {
+    /**
+     * 兼容老版本php构造函数，不能在 __construct() 方法前边，否则报错
+     */
+    function Prpcrypt($k)
+    {
         $this->key = base64_decode($k . "=");
     }
 

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -501,7 +501,7 @@ class Wechat
 	 */
 	public function getRevScanInfo(){
 		if (isset($this->_receive['ScanCodeInfo'])){
-		    if (!is_array($this->_receive['SendPicsInfo'])) {
+		    if (!is_array($this->_receive['ScanCodeInfo'])) {
 		        $array=(array)$this->_receive['ScanCodeInfo'];
 		        $this->_receive['ScanCodeInfo']=$array;
 		    }else {


### PR DESCRIPTION
1. 修复bug: Prpcrypt类 兼容构造函数 位置顺序问题导致报错
>在php 5.4以上，如果同时使用 `__construct()` 方法与 同类名方法 的构造函数，则 `__construct()` 方法 必须在前，否则会报错

2. 公众号、企业号类：修复getJsTicket 方法bug:强制设置jsapi_ticket时，却返回access_token
>(感谢@Treri 发现,fixed #200)

3. 公众号类 修复getRevScanInfo()方法bug
>(感谢@lqhlqy 提出,fixed #205)