### PR TITLE
补充摇一摇周边接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ const EVENT_CARD_USER_DEL = 'user_del_card';        //卡券 - 用户删除卡�
  *  setTMIndustry($id1,$id2='') 模板消息，设置所属行业
  *  addTemplateMessage($tpl_id) 模板消息，添加消息模板
  *  sendTemplateMessage($data) 发送模板消息
+ *  
+ *  多客服接口：
  *  getCustomServiceMessage($data) 获取多客服会话记录
  *  transfer_customer_service($customer_account) 转发多客服消息
  *  getCustomServiceKFlist() 获取多客服客服基本信息
@@ -213,6 +215,7 @@ const EVENT_CARD_USER_DEL = 'user_del_card';        //卡券 - 用户删除卡�
  *  updateKFAccount($account,$nickname,$password) 修改客服账号信息
  *  deleteKFAccount($account) 删除客服账号
  *  setKFHeadImg($account,$imgfile) 上传客服头像
+ *  
  *  querySemantic($uid,$query,$category,$latitude=0,$longitude=0,$city="",$region="") 语义理解接口 参数含义及返回的json内容请查看 **[微信语义理解接口](http://mp.weixin.qq.com/wiki/index.php?title=语义理解)**
  *  getDatacube($type,$subtype,$begin_date,$end_date='') 获取统计数据 参数需注意$type与$subtype的定义
 > 获取统计数据方法 参数定义
@@ -238,6 +241,8 @@ const EVENT_CARD_USER_DEL = 'user_del_card';        //卡券 - 用户删除卡�
 | 接口分析 | 'interface' | 获取接口分析分时数据 | 'summaryhour' | 1 |
 需要注意 `begin_date`和`end_date`的差值需小于“最大时间跨度”（比如最大时间跨度为1时，`begin_date`和`end_date`的差值只能为0，才能小于1）
 
+ *  
+ *  卡券接口：
  *  createCard($data) 创建卡券
  *  updateCard($data) 修改卡券
  *  delCard($card_id) 删除卡券
@@ -257,7 +262,21 @@ const EVENT_CARD_USER_DEL = 'user_del_card';        //卡券 - 用户删除卡�
  *  updateMemberCard($data) 会员卡交易，参数结构请参看卡券开发文档(6.1.2 会员卡交易)章节
  *  updateLuckyMoney($code,$balance,$card_id='') 更新红包金额
  *  setCardTestWhiteList($openid=array(),$user=array()) 设置卡券测试白名单
- 
+ *  
+ *  摇一摇周边接口：
+ *  applyShakeAroundDevice($data) 申请设备ID
+ *  updateShakeAroundDevice($data) 编辑设备的备注信息
+ *  searchShakeAroundDevice($data) 查询设备列表
+ *  bindLocationShakeAroundDevice($device_id,$poi_id,$uuid='',$major=0,$minor=0) 配置设备与门店的关联关系
+ *  bindPageShakeAroundDevice($device_id,$page_ids=array(),$bind=1,$append=1,$uuid='',$major=0,$minor=0) 配置设备与页面的关联关系
+ *  uploadShakeAroundMedia($data) 上传在摇一摇页面展示的图片素材
+ *  addShakeAroundPage($title,$description,$icon_url,$page_url,$comment='') 新增摇一摇出来的页面信息
+ *  updateShakeAroundPage($page_id,$title,$description,$icon_url,$page_url,$comment='') 编辑摇一摇出来的页面信息
+ *  searchShakeAroundPage($page_ids=array(),$begin=0,$count=1) 查询摇一摇已有的页面
+ *  deleteShakeAroundPage($page_ids=array()) 删除摇一摇已有的页面，必须是未与设备关联的页面
+ *  getShakeInfoShakeAroundUser($ticket) 获取摇周边的设备及用户信息
+ *  deviceShakeAroundStatistics($device_id,$begin_date,$end_date,$uuid='',$major=0,$minor=0) 以设备为维度的数据统计接口
+ *  pageShakeAroundStatistics($page_id,$begin_date,$end_date) 以页面为维度的数据统计接口
  
 ## ~~2. wechatext.class.php 非官方扩展API~~  
 **此扩展类库已经不再更新，原因是官方对公众号开放了众多接口，此类库继续维护的意义不大**  

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -190,15 +190,18 @@ class Wechat
 	);
 	///微信摇一摇周边
 	const SHAKEAROUND_DEVICE_APPLYID = '/shakearound/device/applyid?';//申请设备ID
+    const SHAKEAROUND_DEVICE_UPDATE = '/shakearound/device/update?';//编辑设备信息
 	const SHAKEAROUND_DEVICE_SEARCH = '/shakearound/device/search?';//查询设备列表
 	const SHAKEAROUND_DEVICE_BINDLOCATION = '/shakearound/device/bindlocation?';//配置设备与门店ID的关系
 	const SHAKEAROUND_DEVICE_BINDPAGE = '/shakearound/device/bindpage?';//配置设备与页面的绑定关系
+    const SHAKEAROUND_MATERIAL_ADD = '/shakearound/material/add?';//上传摇一摇图片素材
 	const SHAKEAROUND_PAGE_ADD = '/shakearound/page/add?';//增加页面
 	const SHAKEAROUND_PAGE_UPDATE = '/shakearound/page/update?';//编辑页面
 	const SHAKEAROUND_PAGE_SEARCH = '/shakearound/page/search?';//查询页面列表
 	const SHAKEAROUND_PAGE_DELETE = '/shakearound/page/delete?';//删除页面
 	const SHAKEAROUND_USER_GETSHAKEINFO = '/shakearound/user/getshakeinfo?';//获取摇周边的设备及用户信息
 	const SHAKEAROUND_STATISTICS_DEVICE = '/shakearound/statistics/device?';//以设备为维度的数据统计接口
+    const SHAKEAROUND_STATISTICS_PAGE = '/shakearound/statistics/page?';//以页面为维度的数据统计接口
 
 	private $token;
 	private $encodingAesKey;
@@ -3370,16 +3373,18 @@ class Wechat
         }
         return false;
     }
+
     /**
+     * 申请设备ID
      * [applyShakeAroundDevice 申请配置设备所需的UUID、Major、Minor。
      * 若激活率小于50%，不能新增设备。单次新增设备超过500 个，需走人工审核流程。
      * 审核通过后，可用迒回的批次ID 用“查询设备列表”接口拉取本次申请的设备ID]
      * @param array $data
      * array(
-     *      "quantity" => 3,//申请的设备ID 的数量，单次新增设备超过500 个,需走人工审核流程(必填)
+     *      "quantity" => 3,         //申请的设备ID 的数量，单次新增设备超过500 个,需走人工审核流程(必填)
      *      "apply_reason" => "测试",//申请理由(必填)
-     *      "comment" => "测试专用",//备注(非必填)
-     *      "poi_id" => 1234 //设备关联的门店ID(非必填)
+     *      "comment" => "测试专用", //备注(非必填)
+     *      "poi_id" => 1234         //设备关联的门店ID(非必填)
      * )
      * @return boolean|mixed
      * {
@@ -3397,7 +3402,7 @@ class Wechat
         "errcode": 0,
         "errmsg": "success."
         }
-        
+
         apply_id:申请的批次ID，可用在“查询设备列表”接口按批次查询本次申请成功的设备ID
         device_identifiers:指定的设备ID 列表
         device_id:设备编号
@@ -3424,7 +3429,48 @@ class Wechat
         }
         return false;
     }
+
     /**
+     * 编辑设备信息
+     * [updateShakeAroundDevice 编辑设备的备注信息。可用设备ID或完整的UUID、Major、Minor指定设备，二者选其一。]
+     * @param array $data
+     * array(
+     *      "device_identifier" => array(
+     *          		"device_id" => 10011,   //当提供了device_id则不需要使用uuid、major、minor，反之亦然
+     *          		"uuid" => "FDA50693-A4E2-4FB1-AFCF-C6EB07647825",
+     *          		"major" => 1002,
+     *          		"minor" => 1223
+     *      ),
+     *      "comment" => "测试专用", //备注(非必填)
+     * )
+     * {
+        "data": {
+        },
+        "errcode": 0,
+        "errmsg": "success."
+       }
+     * @return boolean
+     * @author binsee<binsee@163.com>
+     * @version 2015-4-20 23:45:00
+     */
+    public function updateShakeAroundDevice($data){
+    	if (!$this->access_token && !$this->checkAuth()) return false;
+    	$result = $this->http_post(self::API_BASE_URL_PREFIX . self::SHAKEAROUND_DEVICE_UPDATE . 'access_token=' . $this->access_token, self::json_encode($data));
+    	$this->log($result);
+        if ($result) {
+            $json = json_decode($result, true);
+            if (!$json || !empty($json['errcode'])) {
+                $this->errCode = $json['errcode'];
+                $this->errMsg  = $json['errmsg'];
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 查询设备列表
      * [searchShakeAroundDevice 查询已有的设备ID、UUID、Major、Minor、激活状态、备注信息、关联门店、关联页面等信息。
      * 可指定设备ID 或完整的UUID、Major、Minor 查询，也可批量拉取设备信息列表。]
      * @param array $data
@@ -3509,12 +3555,11 @@ class Wechat
         }
         return false;
     }
+
     /**
-     * [bindLocationShakeAroundDevice 修改设备关联的门店ID、设备的备注信息。
-     * 可用设备ID 或完整的UUID、Major、Minor指定设备，二者选其一。]
+     * [bindLocationShakeAroundDevice 配置设备与门店的关联关系]
      * @param string $device_id 设备编号，若填了UUID、major、minor，则可不填设备编号，若二者都填，则以设备编号为优先
      * @param int $poi_id 待关联的门店ID
-     * @param string $comment 设备的备注信息
      * @param string $uuid UUID、major、minor，三个信息需填写完整，若填了设备编号，则可不填此信息
      * @param int $major
      * @param int $minor
@@ -3528,10 +3573,10 @@ class Wechat
        }
      * @access public
      * @author polo<gao.bo168@gmail.com>
-     * @version 2015-3-25 下午2:32:18
+     * @version 2015-4-21 00:14:00
      * @copyright Show More
      */
-    public function bindLocationShakeAroundDevice($device_id,$poi_id,$comment,$uuid,$major,$minor){
+    public function bindLocationShakeAroundDevice($device_id,$poi_id,$uuid='',$major=0,$minor=0){
         if (!$this->access_token && !$this->checkAuth()) return false;
         if(!$device_id){
             if(!$uuid || !$major || !$minor){
@@ -3549,8 +3594,7 @@ class Wechat
         }
         $data = array(
             'device_identifier' => $device_identifier,
-            'poi_id' => $poi_id,
-            'comment' => $comment
+            'poi_id' => $poi_id
         );
         $result = $this->http_post(self::API_BASE_URL_PREFIX . self::SHAKEAROUND_DEVICE_BINDLOCATION . 'access_token=' . $this->access_token, self::json_encode($data));
         $this->log($result);
@@ -3561,10 +3605,11 @@ class Wechat
                 $this->errMsg  = $json['errmsg'];
                 return false;
             }
-            return $json;
+            return $json; //这个可以更改为返回true
         }
         return false;
     }
+
     /**
      * [bindPageShakeAroundDevice 配置设备与页面的关联关系。
      * 支持建立或解除关联关系，也支持新增页面或覆盖页面等操作。
@@ -3587,10 +3632,10 @@ class Wechat
        }
      * @access public
      * @author polo<gao.bo168@gmail.com>
-     * @version 2015-3-25 下午2:47:54
+     * @version 2015-4-21 00:31:00
      * @copyright Show More
      */
-    public function bindPageShakeAroundDevice($device_id,$page_ids=array(),$bind=1,$append=1,$uuid,$major,$minor){
+    public function bindPageShakeAroundDevice($device_id,$page_ids=array(),$bind=1,$append=1,$uuid='',$major=0,$minor=0){
         if (!$this->access_token && !$this->checkAuth()) return false;
         if(!$device_id){
             if(!$uuid || !$major || !$minor){
@@ -3625,6 +3670,39 @@ class Wechat
         }
         return false;
     }
+
+    /**
+     * 上传在摇一摇页面展示的图片素材
+     * 注意：数组的键值任意，但文件名前必须加@，使用单引号以避免本地路径斜杠被转义
+     * @param array $data {"media":'@Path\filename.jpg'} 格式限定为：jpg,jpeg,png,gif，图片大小建议120px*120 px，限制不超过200 px *200 px，图片需为正方形。
+     * @return boolean|array
+     * {
+        "data": {
+            "pic_url":"http://shp.qpic.cn/wechat_shakearound_pic/0/1428377032e9dd2797018cad79186e03e8c5aec8dc/120"
+        },
+            "errcode": 0,
+            "errmsg": "success."
+        }
+       }
+     * @author binsee<binsee@163.com>
+     * @version 2015-4-21 00:51:00
+     */
+    public function uploadShakeAroundMedia($data){
+        if (!$this->access_token && !$this->checkAuth()) return false;
+        $result = $this->http_post(self::API_URL_PREFIX.self::SHAKEAROUND_MATERIAL_ADD.'access_token='.$this->access_token,$data,true);
+        if ($result)
+        {
+            $json = json_decode($result,true);
+            if (!$json || !empty($json['errcode'])) {
+                $this->errCode = $json['errcode'];
+                $this->errMsg = $json['errmsg'];
+                return false;
+            }
+            return $json;
+        }
+        return false;
+    }
+
     /**
      * [addShakeAroundPage 增加摇一摇出来的页面信息，包括在摇一摇页面出现的主标题、副标题、图片和点击进去的超链接。]
      * @param string $title 在摇一摇页面展示的主标题，不超过6 个字
@@ -3668,6 +3746,7 @@ class Wechat
         }
         return false;
     }
+
     /**
      * [updateShakeAroundPage 编辑摇一摇出来的页面信息，包括在摇一摇页面出现的主标题、副标题、图片和点击进去的超链接。]
      * @param int $page_id
@@ -3713,6 +3792,7 @@ class Wechat
         }
         return false;
     }
+
     /**
      * [searchShakeAroundPage 查询已有的页面，包括在摇一摇页面出现的主标题、副标题、图片和点击进去的超链接。
      * 提供两种查询方式，①可指定页面ID 查询，②也可批量拉取页面列表。]
@@ -3795,6 +3875,7 @@ class Wechat
         }
         return false;
     }
+
     /**
      * [deleteShakeAroundPage 删除已有的页面，包括在摇一摇页面出现的主标题、副标题、图片和点击进去的超链接。
      * 只有页面与设备没有关联关系时，才可被删除。]
@@ -3833,6 +3914,7 @@ class Wechat
         }
         return false;
     }
+
     /**
      * [getShakeInfoShakeAroundUser 获取设备信息，包括UUID、major、minor，以及距离、openID 等信息。]
      * @param string $ticket 摇周边业务的ticket，可在摇到的URL 中得到，ticket生效时间为30 分钟
@@ -3880,8 +3962,10 @@ class Wechat
         }
         return false;
     }
+
     /**
-     * [deviceShakeAroundStatistics description]
+     * [deviceShakeAroundStatistics 以设备为维度的数据统计接口。
+     * 查询单个设备进行摇周边操作的人数、次数，点击摇周边消息的人数、次数；查询的最长时间跨度为30天。]
      * @param int $device_id 设备编号，若填了UUID、major、minor，即可不填设备编号，二者选其一
      * @param int $begin_date 起始日期时间戳，最长时间跨度为30 天
      * @param int $end_date 结束日期时间戳，最长时间跨度为30 天
@@ -3918,10 +4002,10 @@ class Wechat
      * shake_uv 摇周边的人数
      * @access public
      * @author polo<gao.bo168@gmail.com>
-     * @version 2015-3-25 下午3:39:08
+     * @version 2015-4-21 00:39:00
      * @copyright Show More
      */
-    public function deviceShakeAroundStatistics($device_id,$begin_date,$end_date,$uuid,$major,$minor){
+    public function deviceShakeAroundStatistics($device_id,$begin_date,$end_date,$uuid='',$major=0,$minor=0){
         if (!$this->access_token && !$this->checkAuth()) return false;
         if(!$device_id){
             if(!$uuid || !$major || !$minor){
@@ -3939,6 +4023,65 @@ class Wechat
         }
         $data = array(
             'device_identifier' => $device_identifier,
+            'begin_date' => $begin_date,
+            'end_date' => $end_date
+        );
+        $result = $this->http_post(self::API_BASE_URL_PREFIX . self::SHAKEAROUND_STATISTICS_DEVICE . 'access_token=' . $this->access_token, self::json_encode($data));
+        $this->log($result);
+        if ($result) {
+            $json = json_decode($result, true);
+            if (!$json || !empty($json['errcode'])) {
+                $this->errCode = $json['errcode'];
+                $this->errMsg  = $json['errmsg'];
+                return false;
+            }
+            return $json;
+        }
+        return false;
+    }
+
+
+    /**
+     * [pageShakeAroundStatistics 以页面为维度的数据统计接口。
+     * 查询单个页面通过摇周边摇出来的人数、次数，点击摇周边页面的人数、次数；查询的最长时间跨度为30天。]
+     * @param int $page_id 指定页面的ID
+     * @param int $begin_date 起始日期时间戳，最长时间跨度为30 天
+     * @param int $end_date 结束日期时间戳，最长时间跨度为30 天
+     * @return boolean|mixed
+     * 正确返回JSON 数据示例:
+     * {
+        "data": [
+            {
+                "click_pv": 0,
+                "click_uv": 0,
+                "ftime": 1425052800,
+                "shake_pv": 0,
+                "shake_uv": 0
+            },
+            {
+                "click_pv": 0,
+                "click_uv": 0,
+                "ftime": 1425139200,
+                "shake_pv": 0,
+                "shake_uv": 0
+            }
+        ],
+        "errcode": 0,
+        "errmsg": "success."
+       }
+     * 字段说明:
+     * ftime 当天0 点对应的时间戳
+     * click_pv 点击摇周边消息的次数
+     * click_uv 点击摇周边消息的人数
+     * shake_pv 摇周边的次数
+     * shake_uv 摇周边的人数
+     * @author binsee<binsee@163.com>
+     * @version 2015-4-21 00:43:00
+     */
+    public function pageShakeAroundStatistics($page_id,$begin_date,$end_date){
+        if (!$this->access_token && !$this->checkAuth()) return false;
+        $data = array(
+            'page_id' => $page_id,
             'begin_date' => $begin_date,
             'end_date' => $end_date
         );


### PR DESCRIPTION
公众号类：
1、补充摇一摇周边缺少的接口(编辑设备信息、上传摇一摇图片素材、以页面为维度的数据统计接口)
2、修正部分摇一摇接口备注及代码

README文件：
补充摇一摇周边接口列表