### PR TITLE
Update wechat.class.php

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -1733,12 +1733,16 @@ class Wechat
         {
             if (is_string($result)) {
                 $json = json_decode($result,true);
-                if (isset($json['errcode'])) {
-                    $this->errCode = $json['errcode'];
-                    $this->errMsg = $json['errmsg'];
-                    return false;
+                if ($json) {
+                    if (isset($json['errcode'])) {
+                        $this->errCode = $json['errcode'];
+                        $this->errMsg = $json['errmsg'];
+                        return false;
+                    }
+                    return $json;
+                } else {
+                    return $result;
                 }
-                return $json;
             }
             return $result;
         }


### PR DESCRIPTION
如果获取的素材是图片时，返回的$result是图片的二进制数据，但is_string却判断会是true，因此导致json_decode后为NULL，整个函数返回的结果为NULL。现在增加多一层判断json decode是否成功，不成功的直接返回$result。