### PR TITLE
更新临时二维码有效期最大值为 604800 秒

### DIFF
--- a/wechat.class.php
+++ b/wechat.class.php
@@ -2031,10 +2031,10 @@ class Wechat
 	 * 创建二维码ticket
 	 * @param int|string $scene_id 自定义追踪id,临时二维码只能用数值型
 	 * @param int $type 0:临时二维码；1:永久二维码(此时expire参数无效)；2:永久二维码(此时expire参数无效)
-	 * @param int $expire 临时二维码有效期，最大为1800秒
-	 * @return array('ticket'=>'qrcode字串','expire_seconds'=>1800,'url'=>'二维码图片解析后的地址')
+	 * @param int $expire 临时二维码有效期，最大为604800秒
+	 * @return array('ticket'=>'qrcode字串','expire_seconds'=>604800,'url'=>'二维码图片解析后的地址')
 	 */
-	public function getQRCode($scene_id,$type=0,$expire=1800){
+	public function getQRCode($scene_id,$type=0,$expire=604800){
 		if (!$this->access_token && !$this->checkAuth()) return false;
 		$type = ($type && is_string($scene_id))?2:$type;
 		$data = array(


### PR DESCRIPTION
根据最新官方文档（ http://mp.weixin.qq.com/wiki/18/28fc21e7ed87bec960651f0ce873ef8a.html ）「expire_seconds	 该二维码有效时间，以秒为单位。 最大不超过604800（即7天）」,将临时二维码有效期最大值更新为 604800 秒。