### PR TITLE
修正json_encode转义序列bug

### DIFF
--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -202,7 +202,7 @@ class Wechat
 	            elseif ($value === true)
 	            $str .= 'true';
 	            else
-	                $str .= '"' . addslashes ( $value ) . '"'; //All other things
+	                $str .= '"' .addcslashes($value, "\\\"\n\r\t/"). '"'; //All other things
 	            // :TODO: Is there any more datatype we should be in the lookout for? (Object?)
 	            $parts [] = $str;
 	        }


### PR DESCRIPTION
微信模板消息\n可换行，json_encode 需保持原始字符模样