### PR TITLE
fix media upload bug

### DIFF
--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -273,6 +273,9 @@ class Wechat
 		curl_setopt($oCurl, CURLOPT_RETURNTRANSFER, 1 );
 		curl_setopt($oCurl, CURLOPT_POST,true);
 		curl_setopt($oCurl, CURLOPT_POSTFIELDS,$strPOST);
+		if(PHP_VERSION_ID >= 50500){
+			curl_setopt($oCurl, CURLOPT_SAFE_UPLOAD, FALSE);
+		}
 		$sContent = curl_exec($oCurl);
 		$aStatus = curl_getinfo($oCurl);
 		curl_close($oCurl);

--- a/wechat.class.php
+++ b/wechat.class.php
@@ -1136,6 +1136,9 @@ class Wechat
 		curl_setopt($oCurl, CURLOPT_RETURNTRANSFER, 1 );
 		curl_setopt($oCurl, CURLOPT_POST,true);
 		curl_setopt($oCurl, CURLOPT_POSTFIELDS,$strPOST);
+		if(PHP_VERSION_ID >= 50500){
+			curl_setopt($oCurl, CURLOPT_SAFE_UPLOAD, FALSE);
+		}
 		$sContent = curl_exec($oCurl);
 		$aStatus = curl_getinfo($oCurl);
 		curl_close($oCurl);


### PR DESCRIPTION
当我用 5.6 版去调微信服务号API uploadImg() 方法上传图片时出现 code:41005 各种实验就是code:41005后搜索查看 http://www.yaocheap.com/phptec/702.html 得以解决，请修正