### PR TITLE
修复企业微信获取不到access_token问题

### DIFF
--- a/qywechat.class.php
+++ b/qywechat.class.php
@@ -894,7 +894,7 @@ class Wechat
 		if ($result)
 		{
 			$json = json_decode($result,true);
-			if (!$json || isset($json['errcode'])) {
+			if (!$json || !empty($json['errcode'])) {
 				$this->errCode = $json['errcode'];
 				$this->errMsg = $json['errmsg'];
 				return false;


### PR DESCRIPTION
企业微信升级后获取access_token接口获取成功的状态码中多了 errcode=0，导致原来的 isset 判断失效。修正为 !empty